### PR TITLE
Plugin compatibility with Piwik 2.16.0-b6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
   global:
     - PLUGIN_NAME=CustomAlerts
     - PIWIK_ROOT_DIR=$TRAVIS_BUILD_DIR/piwik
-    - PIWIK_LATEST_STABLE_TEST_TARGET=2.15.0-rc4
+    - PIWIK_LATEST_STABLE_TEST_TARGET=2.16.0-b6
     - secure: "Kwg24EJP/yqZ2eY4XkNDT1rKi78hS2Z9rmovuk0h9+R6jfFAV3BGWf/nsSEmAbU3yC0ifpJg560jURrOmnjAL3q+ehJVtk3joGsfHrNFHzQ+042qSZlO8uC2yegvtCPMmhDM9QotmOgrRfqJ51HQ1F6NxcgyTtWer/ghrFD14QU="
     - secure: "O4Y94yPmbvry1wAaU8bJpV7tZO8uwaCrZTMAe8QTAJHpMkmdKrDr5zD5jwWVEKCziXLqvZdqRk2OLoeM1so/8F2hrKycS/luvIzhbqOpvBrSFPnQfY4Ty6BTjrAy3j3k/c6rL0QLMHNFHb5uL3Ex+La6Y5RkcTCIbEwTjU7f/D4="
   matrix:


### PR DESCRIPTION
If you merge this PR manually and there is a version bump, you must remember to tag the new version.

This PR contains changes required to make CustomAlerts compatible with Piwik 2.16.0-b6.

It should be reviewed, then after all similar PRs are reviewed, they will be merged by a command.

* [ ] Reviewed (make sure to confirm build is green).

Check the above box to let the command know this PR has been reviewed.